### PR TITLE
add Github Action for Cosmopolitan Libc build

### DIFF
--- a/.github/workflows/cosmo.yml
+++ b/.github/workflows/cosmo.yml
@@ -1,0 +1,44 @@
+name: Build cxx with Cosmopolitan Libc
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+  push:
+    tags:
+      - "*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+
+  release-cosmo:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
+    name: Build release binaries for Cosmo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@master
+      - name: setup cosmocc
+        run: |
+          sudo mkdir -p /sc
+          sudo chmod -R 0777 /sc 
+          cd /sc
+          wget https://github.com/jart/cosmopolitan/releases/download/3.3.3/cosmocc-3.3.3.zip
+          mkdir cosmo
+          cd cosmo
+          unzip ../cosmocc-3.3.3.zip
+          sudo cp ./bin/ape-x86_64.elf /usr/bin/ape
+          sudo sh -c "echo ':APE:M::MZqFpD::/usr/bin/ape:' >/proc/sys/fs/binfmt_misc/register"
+      - name: build APE binary of cxx
+        run: |
+          make -j CC="/sc/cosmo/bin/cosmocc"
+          chmod +x src/cxx
+      - name: push binary to github
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: |
+            src/cxx


### PR DESCRIPTION
This PR adds a Github Actions workflow to build `cxx` from source with Cosmopolitan Libc with every release.
The resulting binary should work on `x86_64` (Linux/BSDs/Windows/MacOS), and `aarch64` (Linux/MacOS) as per the Cosmopolitan v3.3.3 [README](https://github.com/jart/cosmopolitan/tree/3.3.3?tab=readme-ov-file#support-vector).

An example `cxx` binary is available here: https://github.com/ahgamut/cxx/releases/tag/untagged-41b8dd7f7a169bcd65bf  download and `chmod +x` (or rename to `cxx.exe` on Windows) to run the executable from the command-line.